### PR TITLE
[infinite scroll pagination] Remove deprecated style "headline6"

### DIFF
--- a/lib/src/ui/default_indicators/first_page_exception_indicator.dart
+++ b/lib/src/ui/default_indicators/first_page_exception_indicator.dart
@@ -24,7 +24,7 @@ class FirstPageExceptionIndicator extends StatelessWidget {
             Text(
               title,
               textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.headline6,
+              style: Theme.of(context).textTheme.titleLarge,
             ),
             if (message != null)
               const SizedBox(


### PR DESCRIPTION
In this PR, I've removed deprecated style and replaced it with titleLarge